### PR TITLE
Upgrade to React Flow v11 API

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,6 @@
     "next": "latest",
     "react": "latest",
     "react-dom": "latest",
-    "reactflow": "^11.11.4"
+    "reactflow": "latest"
   }
 }

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,19 +1,23 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback } from 'react';
 import ReactFlow, {
   Background,
   Controls,
   MiniMap,
   addEdge,
-  removeElements
+  useEdgesState,
+  useNodesState
 } from 'reactflow';
 
-const initialElements = [
+const initialNodes = [
   { id: '1', type: 'input', data: { label: 'GitHub' }, position: { x: 100, y: 50 } },
   { id: '2', data: { label: 'Vercel' }, position: { x: 400, y: 50 } },
   { id: '3', data: { label: 'Supabase' }, position: { x: 250, y: 200 } },
   { id: '4', data: { label: 'Cursor' }, position: { x: 100, y: 350 } },
   { id: '5', data: { label: 'Codex' }, position: { x: 400, y: 350 } },
-  { id: '6', data: { label: 'Operator (ChatGPT)' }, position: { x: 250, y: 500 } },
+  { id: '6', data: { label: 'Operator (ChatGPT)' }, position: { x: 250, y: 500 } }
+];
+
+const initialEdges = [
   { id: 'e1-2', source: '1', target: '2', animated: true },
   { id: 'e2-3', source: '2', target: '3' },
   { id: 'e3-4', source: '3', target: '4' },
@@ -23,33 +27,22 @@ const initialElements = [
 ];
 
 export default function Home() {
-  const [elements, setElements] = useState(initialElements);
+  const [nodes, setNodes, onNodesChange] = useNodesState(initialNodes);
+  const [edges, setEdges, onEdgesChange] = useEdgesState(initialEdges);
 
-  const onElementsRemove = useCallback((elementsToRemove) =>
-    setElements((els) => removeElements(elementsToRemove, els)),
+  const onConnect = useCallback(
+    (params) => setEdges((eds) => addEdge({ ...params, animated: true }, eds)),
     []
   );
-
-  const onConnect = useCallback((params) =>
-    setElements((els) => addEdge({ ...params, animated: true }, els)),
-    []
-  );
-
-  const onNodeDragStop = useCallback((event, node) => {
-    setElements((els) =>
-      els.map((el) =>
-        el.id === node.id ? { ...el, position: node.position } : el
-      )
-    );
-  }, []);
 
   return (
     <div style={{ height: '100vh' }}>
       <ReactFlow
-        elements={elements}
-        onElementsRemove={onElementsRemove}
+        nodes={nodes}
+        edges={edges}
+        onNodesChange={onNodesChange}
+        onEdgesChange={onEdgesChange}
         onConnect={onConnect}
-        onNodeDragStop={onNodeDragStop}
         deleteKeyCode={46} // 'delete' key
       >
         <MiniMap />


### PR DESCRIPTION
## Summary
- refactor flow diagram to use `nodes` and `edges` with React Flow v11 hooks
- set `reactflow` dependency to `latest`

## Testing
- `npm test` *(fails: Missing script)*
- `npm install` *(fails: Exit handler never called)*
