### PR TITLE
Pin Next and React versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
     "start": "next start"
   },
   "dependencies": {
-    "next": "latest",
-    "react": "latest",
-    "react-dom": "latest",
+    "next": "13.4.1",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
     "reactflow": "^11.11.4"
   }
 }


### PR DESCRIPTION
## Summary
- lock in tested versions for Next.js and React

## Testing
- `npm --version`