### PR TITLE
Add modular FlowDiagram component

### DIFF
--- a/src/components/DepartmentNode.tsx
+++ b/src/components/DepartmentNode.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Handle, NodeProps, Position } from 'reactflow';
 import AgentTools from './AgentTools';
 
@@ -9,10 +9,36 @@ type Data = {
 };
 
 export default function DepartmentNode({ data }: NodeProps<Data>) {
+  const [editing, setEditing] = useState(false);
+  const [name, setName] = useState(data.name);
+  const [role, setRole] = useState(data.role);
+
+  const toggleEdit = () => setEditing(!editing);
+
   return (
-    <div className="bg-white border rounded shadow p-2 text-center min-w-[120px]">
-      <div className="font-bold">{data.name}</div>
-      <div className="text-xs text-gray-500">{data.role}</div>
+    <div
+      onDoubleClick={toggleEdit}
+      className="bg-white border rounded shadow p-2 text-center min-w-[120px] hover:ring-2 hover:ring-blue-400"
+    >
+      {editing ? (
+        <>
+          <input
+            className="w-full border text-center text-sm mb-1"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+          />
+          <input
+            className="w-full border text-center text-xs text-gray-500"
+            value={role}
+            onChange={(e) => setRole(e.target.value)}
+          />
+        </>
+      ) : (
+        <>
+          <div className="font-bold">{name}</div>
+          <div className="text-xs text-gray-500">{role}</div>
+        </>
+      )}
       <AgentTools tools={data.tools} />
       <Handle type="target" position={Position.Top} />
       <Handle type="source" position={Position.Bottom} />

--- a/src/components/FlowDiagram.tsx
+++ b/src/components/FlowDiagram.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import ReactFlow, {
+  Background,
+  Controls,
+  MiniMap,
+  Node,
+  Edge,
+  useNodesState,
+  useEdgesState
+} from 'reactflow';
+import 'reactflow/dist/style.css';
+import DepartmentNode from './DepartmentNode';
+import { orgData } from '../data/orgData';
+import { OrgNode } from '../types/OrgNode';
+
+interface FlattenResult {
+  nodes: Node[];
+  edges: Edge[];
+}
+
+let idCounter = 0;
+const getId = () => `${idCounter++}`;
+
+function flatten(root: OrgNode): FlattenResult {
+  const nodes: Node[] = [];
+  const edges: Edge[] = [];
+
+  const walk = (node: OrgNode, depth = 0, index = 0, parentId?: string) => {
+    const id = getId();
+    node.id = id;
+    nodes.push({
+      id,
+      type: 'department',
+      data: { name: node.name, role: node.role, tools: node.tools },
+      position: { x: depth * 250, y: index * 150 }
+    });
+    if (parentId) {
+      edges.push({ id: `e${parentId}-${id}`, source: parentId, target: id, type: 'hierarchy' });
+    }
+    node.children?.forEach((child, idx) => walk(child, depth + 1, index * 3 + idx, id));
+  };
+
+  walk(root);
+  return { nodes, edges };
+}
+
+export default function FlowDiagram() {
+  const { nodes: initialNodes, edges: initialEdges } = flatten(orgData);
+  const [nodes, setNodes, onNodesChange] = useNodesState(initialNodes);
+  const [edges, setEdges, onEdgesChange] = useEdgesState(initialEdges);
+
+  return (
+    <div className="w-full h-screen">
+      <ReactFlow
+        nodes={nodes}
+        edges={edges}
+        nodeTypes={{ department: DepartmentNode }}
+        onNodesChange={onNodesChange}
+        onEdgesChange={onEdgesChange}
+        fitView
+      >
+        <MiniMap />
+        <Controls />
+        <Background />
+      </ReactFlow>
+    </div>
+  );
+}

--- a/src/data/orgData.ts
+++ b/src/data/orgData.ts
@@ -1,10 +1,4 @@
-export interface OrgNode {
-  id?: string;
-  name: string;
-  role: string;
-  tools?: string[];
-  children?: OrgNode[];
-}
+import { OrgNode } from '../types/OrgNode';
 
 export const orgData: OrgNode = {
   name: 'Chief AI Agent',

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,8 +1,8 @@
 import dynamic from 'next/dynamic';
 import React from 'react';
 
-const OrgChartCanvas = dynamic(() => import('../components/OrgChartCanvas'), { ssr: false });
+const FlowDiagram = dynamic(() => import('../components/FlowDiagram'), { ssr: false });
 
 export default function Home() {
-  return <OrgChartCanvas />;
+  return <FlowDiagram />;
 }

--- a/src/types/OrgNode.ts
+++ b/src/types/OrgNode.ts
@@ -1,0 +1,7 @@
+export interface OrgNode {
+  id?: string;
+  name: string;
+  role: string;
+  tools?: string[];
+  children?: OrgNode[];
+}


### PR DESCRIPTION
## Summary
- introduce `FlowDiagram.tsx` with ReactFlow integration
- update `DepartmentNode` for inline editing and hover highlight
- move `OrgNode` type to `src/types`
- use new type in `orgData`
- update index page to load `FlowDiagram`

## Testing
- `npm run build` *(fails: next not found)*