### PR TITLE
Fix OrgChartCanvas imports

### DIFF
--- a/src/components/OrgChartCanvas.tsx
+++ b/src/components/OrgChartCanvas.tsx
@@ -10,7 +10,8 @@ import ReactFlow, {
 } from 'reactflow';
 import 'reactflow/dist/style.css';
 import DepartmentNode from './DepartmentNode';
-import { orgData, OrgNode } from '../data/orgData';
+import { orgData } from '../data/orgData';
+import { OrgNode } from '../types/OrgNode';
 
 interface FlattenResult {
   nodes: Node[];


### PR DESCRIPTION
## Summary
- fix OrgChartCanvas import of `OrgNode`

## Testing
- `npm run build` *(fails: `next` not found)*