### PR TITLE
Add sample ReactFlow org chart

### DIFF
--- a/src/components/AgentTools.tsx
+++ b/src/components/AgentTools.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Mail, Github, Database, Bot, MessageCircle } from 'lucide-react';
+import { Mail, Github, Database, Bot, MessageCircle, Slack } from 'lucide-react';
 
 const icons: Record<string, React.ReactNode> = {
   gmail: <Mail size={16} />,
@@ -7,6 +7,7 @@ const icons: Record<string, React.ReactNode> = {
   notion: <Database size={16} />,
   chatgpt: <Bot size={16} />,
   discord: <MessageCircle size={16} />,
+  slack: <Slack size={16} />,
   vercel: <Database size={16} />,
 };
 

--- a/src/components/DepartmentNode.tsx
+++ b/src/components/DepartmentNode.tsx
@@ -6,6 +6,8 @@ type Data = {
   name: string;
   role: string;
   tools?: string[];
+  type?: string;
+  department?: string;
 };
 
 export default function DepartmentNode({ data }: NodeProps<Data>) {
@@ -15,10 +17,21 @@ export default function DepartmentNode({ data }: NodeProps<Data>) {
 
   const toggleEdit = () => setEditing(!editing);
 
+  const colorMap: Record<string, string> = {
+    Executive: 'bg-blue-100',
+    ChiefAgent: 'bg-purple-100',
+    DepartmentHead: 'bg-green-100',
+    SubFunction: 'bg-yellow-100',
+    IndividualAgent: 'bg-gray-100',
+    Database: 'bg-gray-200',
+  };
+
+  const bgClass = colorMap[data.type ?? 'DepartmentHead'];
+
   return (
     <div
       onDoubleClick={toggleEdit}
-      className="bg-white border rounded shadow p-2 text-center min-w-[120px] hover:ring-2 hover:ring-blue-400"
+      className={`${bgClass} border rounded shadow p-2 text-center min-w-[120px] hover:ring-2 hover:ring-blue-400`}
     >
       {editing ? (
         <>

--- a/src/components/FlowDiagram.tsx
+++ b/src/components/FlowDiagram.tsx
@@ -30,8 +30,14 @@ function flatten(root: OrgNode): FlattenResult {
     node.id = id;
     nodes.push({
       id,
-      type: 'department',
-      data: { name: node.name, role: node.role, tools: node.tools },
+      type: 'orgNode',
+      data: {
+        name: node.name,
+        role: node.role,
+        tools: node.tools,
+        type: node.type,
+        department: node.department,
+      },
       position: { x: depth * 250, y: index * 150 }
     });
     if (parentId) {
@@ -54,7 +60,7 @@ export default function FlowDiagram() {
       <ReactFlow
         nodes={nodes}
         edges={edges}
-        nodeTypes={{ department: DepartmentNode }}
+        nodeTypes={{ orgNode: DepartmentNode }}
         onNodesChange={onNodesChange}
         onEdgesChange={onEdgesChange}
         fitView

--- a/src/data/orgData.ts
+++ b/src/data/orgData.ts
@@ -1,35 +1,60 @@
 import { OrgNode } from '../types/OrgNode';
 
+// Sample organisational structure consisting of an executive chain and
+// three departments. This data drives the React Flow diagram.
 export const orgData: OrgNode = {
-  name: 'Chief AI Agent',
-  role: 'Central Hub',
-  tools: ['notion', 'chatgpt'],
+  name: 'Frank Greeff',
+  role: 'CEO',
+  type: 'Executive',
+  tools: ['gmail'],
   children: [
     {
-      name: 'Rowan',
-      role: 'Marketing Head',
-      tools: ['discord', 'gmail'],
+      name: 'Jacques Greeff',
+      role: 'CTO',
+      type: 'Executive',
+      tools: ['gmail'],
       children: [
-        { name: 'Socials Manager', role: 'Agent', tools: ['discord'] },
-        { name: 'CRM Suggestions', role: 'Agent', tools: ['gmail'] }
-      ]
-    },
-    {
-      name: 'Gatsby',
-      role: 'Engineering Lead',
-      tools: ['github'],
-      children: [
-        { name: 'Deployment', role: 'Agent', tools: ['vercel'] },
-        { name: 'QA Bot', role: 'Agent', tools: ['github'] }
-      ]
-    },
-    {
-      name: 'Blair',
-      role: 'Finance Lead',
-      tools: ['notion'],
-      children: [
-        { name: 'VC Matching', role: 'Agent', tools: ['gmail'] },
-        { name: 'Budget Tracker', role: 'Agent', tools: ['notion'] }
+        {
+          name: 'Chief AI Agent',
+          role: 'Central Hub',
+          type: 'ChiefAgent',
+          tools: ['notion', 'chatgpt'],
+          children: [
+            {
+              name: 'Blair',
+              role: 'Marketing Head',
+              type: 'DepartmentHead',
+              department: 'marketing',
+              tools: ['gmail', 'slack'],
+              children: [
+                { name: 'Socials Manager', role: 'SubFunction', type: 'SubFunction', tools: ['slack'] },
+                { name: 'CRM Suggestions', role: 'SubFunction', type: 'SubFunction', tools: ['gmail'] }
+              ]
+            },
+            {
+              name: 'Nolan',
+              role: 'Engineering Lead',
+              type: 'DepartmentHead',
+              department: 'engineering',
+              tools: ['github'],
+              children: [
+                { name: 'Deployment', role: 'SubFunction', type: 'SubFunction', tools: ['vercel'] },
+                { name: 'QA Bot', role: 'SubFunction', type: 'SubFunction', tools: ['github'] }
+              ]
+            },
+            {
+              name: 'Gatsby',
+              role: 'Finance Lead',
+              type: 'DepartmentHead',
+              department: 'finance',
+              tools: ['notion'],
+              children: [
+                { name: 'VC Matching', role: 'SubFunction', type: 'SubFunction', tools: ['gmail'] },
+                { name: 'Budget Tracker', role: 'SubFunction', type: 'SubFunction', tools: ['notion'] }
+              ]
+            }
+          ]
+        }
       ]
     }
   ]

--- a/src/types/OrgNode.ts
+++ b/src/types/OrgNode.ts
@@ -3,5 +3,12 @@ export interface OrgNode {
   name: string;
   role: string;
   tools?: string[];
+  /**
+   * Optional semantic type of the node. Examples: 'Executive', 'ChiefAgent',
+   * 'DepartmentHead', 'SubFunction', 'IndividualAgent', 'Database'.
+   */
+  type?: string;
+  /** Optional department label used for color coding */
+  department?: string;
   children?: OrgNode[];
 }


### PR DESCRIPTION
## Summary
- expand `OrgNode` types
- add executive chain and departments in `orgData`
- color-code nodes by type in `DepartmentNode`
- render node extras in `AgentTools`
- generate nodes from updated data in `FlowDiagram`

## Testing
- `npm run build` *(fails: next not found)*
- `npx tsc -p tsconfig.json` *(fails: Cannot find type definition file for 'react')*